### PR TITLE
Responsive game position

### DIFF
--- a/CSS/style.css
+++ b/CSS/style.css
@@ -372,7 +372,6 @@ body, html {
 
 #timerContainer {
   position: absolute;
-  top: -77px; /* Adjust positioning based on the screen layout */
   right: -78%; /* Positioning on the top-right of the screen */
   transform: translateX(50%);
   width: 300px; /* Adjust size based on the PNG frame */

--- a/CSS/style.css
+++ b/CSS/style.css
@@ -280,7 +280,7 @@ body, html {
 
 
 
-  
+
 /* Game Screen Styles */
 #gameContainer {
   display: none; /* Initially hide the game screen */
@@ -738,8 +738,8 @@ body, html {
 /* Return Button */
 #returnBtn {
   position: absolute;
-  bottom: 1px; 
-  right: 540px;  
+  bottom: 1px;
+  right: 540px;
   background: none;
   border: none;
   cursor: pointer;
@@ -814,7 +814,7 @@ body, html {
 /* Reveal Button */
 #revealBtn {
   position: absolute;
-  bottom: 1px; 
+  bottom: 1px;
   right: 632px;  /* Adjusted to place next to return button */
   background: none;
   border: none;

--- a/CSS/style_mobile.css
+++ b/CSS/style_mobile.css
@@ -280,7 +280,7 @@ body, html {
 
 
 
-  
+
 /* Game Screen Styles */
 #gameContainer {
   display: none; /* Initially hide the game screen */
@@ -681,7 +681,7 @@ body, html {
 
 #soundToggleGame {
   position: absolute;
-  bottom: 916px; 
+  bottom: 916px;
   right: -190px;  /* Adjusted to place next to return button */
   background: none;
   border: none;
@@ -701,7 +701,7 @@ body, html {
 
 #helpBtn {
   position: absolute;
-  bottom: 910px; 
+  bottom: 910px;
   right: -360px;  /* Adjusted to place next to return button */
   background: none;
   border: none;
@@ -754,7 +754,7 @@ body, html {
 /* Return Button */
 #returnBtn {
   position: absolute;
-  bottom: 910px; 
+  bottom: 910px;
   right: -30px;  /* Adjusted to place next to return button */
   background: none;
   border: none;
@@ -835,7 +835,7 @@ body, html {
 /* Reveal Button */
 #revealBtn {
   position: absolute;
-  bottom: 910px; 
+  bottom: 910px;
   right: 135px;  /* Adjusted to place next to return button */
   background: none;
   border: none;

--- a/CSS/style_mobile.css
+++ b/CSS/style_mobile.css
@@ -293,7 +293,6 @@ body, html {
   flex-direction: column;
   overflow: hidden;
   position: absolute; /* Use absolute positioning to control placement */
-  top: 0%;
   left: 50%;
   transform: translate(-50%, -50%) scale(1.1);
   overflow: hidden; /* Prevents scrolling within the gameContainer */


### PR DESCRIPTION
This PR positions the game better so that it stays within the screen height regardless of device.

By removing the `top` positioning in the stylesheet the game is automatically positioned better. It might be a bit lower than before but at least it stays within the screen all the time.

Tested in Firefox for Mac (see recordings) and in Safari for iOS.

# Before

Here you can see the red and blue line ending up outside of the device boundaries.

![Screen Recording 2024-11-08 at 11 32 43](https://github.com/user-attachments/assets/fd55defa-712a-40fb-aca6-e2f7103daca1)

# After

![Screen Recording 2024-11-08 at 11 32 20](https://github.com/user-attachments/assets/38955643-7290-46bf-b811-d5fb12e53b1b)
